### PR TITLE
Fix RegisterNGORequestAdmin avatar error. Display avatar preview.

### DIFF
--- a/ro_help/hub/admin.py
+++ b/ro_help/hub/admin.py
@@ -247,6 +247,7 @@ class RegisterNGORequestAdmin(admin.ModelAdmin):
         "active",
         "resolved_on",
         "get_avatar",
+        "avatar",
     )
     list_display = [
         "name",
@@ -263,7 +264,7 @@ class RegisterNGORequestAdmin(admin.ModelAdmin):
         "get_statute",
     ]
     actions = ["create_account"]
-    readonly_fields = ["active", "resolved_on", "registered_on"]
+    readonly_fields = ["active", "resolved_on", "registered_on", "get_avatar"]
     inlines = [RegisterNGORequestVoteInline]
 
     def get_changeform_initial_data(self, request):
@@ -296,7 +297,7 @@ class RegisterNGORequestAdmin(admin.ModelAdmin):
             return format_html(f"<img src='{obj.avatar.url}' width='200'>")
         return "-"
 
-    get_avatar.short_description = "Avatar"
+    get_avatar.short_description = _("Avatar Preview")
 
     def voters(self, obj):
         return ",".join(obj.votes.values_list("entity", flat=True))


### PR DESCRIPTION
Fixes an error while trying to create/edit a RegisterNGORequest:
![image](https://user-images.githubusercontent.com/63551/77820403-ca7bf180-70ea-11ea-9931-44577e3ad8eb.png)

Adds a new avatar preview field:
![image](https://user-images.githubusercontent.com/63551/77820785-6d356f80-70ed-11ea-9c58-8b96ccb81efd.png)

Note: makemessages generated a lot of unrelated changes, so I didn't include po/mo changes in this PR to avoid conflicts.