### PR TITLE
Custom password validator.

### DIFF
--- a/ro_help/hub/password_validation.py
+++ b/ro_help/hub/password_validation.py
@@ -1,0 +1,19 @@
+from django.utils.translation import ugettext_lazy as _
+from django.core.exceptions import ValidationError
+from django.contrib.auth.hashers import check_password
+
+
+class PasswordDifferentFromPrevious:
+    def validate(self, password, user=None):
+        if not user:
+            return
+
+        # If the newly provided password is in fact still the old passoword
+        # consider it invalid
+        if check_password(password, user.password):
+            raise ValidationError(
+                _("Your new password must be different."),
+            )
+
+    def get_help_text(self):
+        return _("Please correct the error below. Your new password must be different. Please try again.")

--- a/ro_help/hub/password_validation.py
+++ b/ro_help/hub/password_validation.py
@@ -8,7 +8,7 @@ class PasswordDifferentFromPrevious:
         if not user:
             return
 
-        # If the newly provided password is in fact still the old passoword
+        # If the newly provided password is in fact still the old password
         # consider it invalid
         if check_password(password, user.password):
             raise ValidationError(

--- a/ro_help/ro_help/settings/base.py
+++ b/ro_help/ro_help/settings/base.py
@@ -123,6 +123,7 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
+    {"NAME": "hub.password_validation.PasswordDifferentFromPrevious"}
 ]
 
 


### PR DESCRIPTION
### What does it fix?

Closes https://github.com/code4romania/ro-help/issues/142

### How has it been tested?

To test this locally you'll have to change `dev.py` settings file and make sure that `AUTH_PASSWORD_VALIDATORS` is not an empty list but something like:

```
AUTH_PASSWORD_VALIDATORS = {"NAME": "hub.password_validation.PasswordDifferentFromPrevious"}
```

Then, from the admin try to change the password of a user to the same password (as in, attempting to re-set the same password). It should throw a validation error as requested in the Github issue.
