### PR TITLE
Issue #110 - maintain scroll position on pagination buttons clicked

### DIFF
--- a/ro_help/hub/templates/base.html
+++ b/ro_help/hub/templates/base.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="{% static "css/hub.css" %}">
     <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
     <script src="{% static "js/navbar.js" %}"></script>
+    <script src="{% static "js/scroll.js" %}"></script>
     <script src="{% static 'js/bulma-collapsible.min.js' %}"></script>
     <title>RO Help</title>
 </head>

--- a/ro_help/static/js/scroll.js
+++ b/ro_help/static/js/scroll.js
@@ -1,0 +1,10 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const scrollPos = localStorage.getItem('scrollPos');
+    if (scrollPos) {
+        window.scrollTo(0, parseFloat(scrollPos));
+    }
+});
+
+window.onbeforeunload = function () {
+    localStorage.setItem('scrollPos', window.scrollY.toString());
+};


### PR DESCRIPTION
Closes #110 

It saves scroll position Y, every time before a page unloads, and on page load it sets the previous one.

Manually tested it locally, tested the next, previous, last, first buttons at the top and also at the button of the pagination section.