### PR TITLE
added ngo details button on needs card.

### DIFF
--- a/ro_help/hub/templates/ngo/list.html
+++ b/ro_help/hub/templates/ngo/list.html
@@ -198,6 +198,10 @@
                         {% trans "I can help" %}
                     {% endif %}
                 </a>
+                <a class="button is-flex has-background-info has-text-weight-bold has-text-white"
+                   href="{% url 'ngo-detail' need.ngo.pk %}">
+                    {% trans "NGO Details" %}
+                </a>
             </div>
 
         </div>


### PR DESCRIPTION
### What does it fix?

Closes https://github.com/code4romania/ro-help/issues/135

`need` cards from `list.html` now display a button which links to NGO's detail page making it easier to access the overview for a particular NGO.

### How has it been tested?

<img width="872" alt="Screenshot 2020-03-30 at 12 00 32" src="https://user-images.githubusercontent.com/12795061/77894660-3e9ace80-727e-11ea-9f29-88b446604333.png">
