### PR TITLE
redirect to index after logout.

### DIFF
--- a/ro_help/hub/templates/header.html
+++ b/ro_help/hub/templates/header.html
@@ -33,7 +33,7 @@
                     <a  href="{% url 'admin:index' %}" class="navbar-item">
                         {% trans "Admin Panel" %}
                     </a>
-                    <a  href="{% url 'material:logout' %}?next={{request.get_full_path|urlencode}}" class="navbar-item">
+                    <a  href="{% url 'material:logout' %}" class="navbar-item">
                         {% trans "Logout" %}
                     </a>
                     {% else %}

--- a/ro_help/ro_help/settings/base.py
+++ b/ro_help/ro_help/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 import os
 
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 import environ
@@ -239,6 +240,8 @@ RED_CROSS_NAME = "Crucea Rosie"
 
 RECAPTCHA_PUBLIC_KEY = env("RECAPTCHA_PUBLIC_KEY")
 RECAPTCHA_PRIVATE_KEY = env("RECAPTCHA_PRIVATE_KEY")
+
+LOGOUT_REDIRECT_URL = reverse_lazy('ngos')
 
 if env("RECAPTCHA_PUBLIC_KEY"):
     RECAPTCHA_PUBLIC_KEY = env("RECAPTCHA_PUBLIC_KEY")


### PR DESCRIPTION
### What does it fix?

Closes #235 

Using Django's `LOGOUT_REDIRECT_URL` we can specify where to redirect the user after log out. This means that we can drop the `next` arg used in `header.html` for log out action as well
