### PR TITLE
fixed scroll to netopia form when kind=money.

### DIFF
--- a/ro_help/hub/templates/ngo/detail.html
+++ b/ro_help/hub/templates/ngo/detail.html
@@ -69,8 +69,7 @@
                             </div>
                         </div>
 
-
-                        <form method="GET" action="{% url 'ngo-donate' ngo.pk %}">
+                        <form method="GET" action="{% url 'ngo-donate' ngo.pk %}#donation-form">
                             <div class="columns is-mobile">
                                 <div class="column is-two-thirds-desktop is-half-mobile">
                                     <div class="control">
@@ -84,7 +83,7 @@
                          </form>
                     </div>
                 {% endif %}
-                
+
                 {% if ngo.accepts_transfer %}
                     <div class="container">
                         <div class="container donate-hero">

--- a/ro_help/hub/templates/ngo/detail.html
+++ b/ro_help/hub/templates/ngo/detail.html
@@ -40,7 +40,7 @@
                 </span>
                 <span>{% trans "Donate money" %}</span>
             </div>
-            <a href="#donate-money" data-action="collapse" class="card-header-icon is-hidden-fullscreen"
+            <a href="#money-accordion" data-action="collapse" class="card-header-icon is-hidden-fullscreen"
                aria-label="more options">
                 <span class="icon">
                     <i class="fas fa-angle-down" aria-hidden="true"></i>
@@ -48,7 +48,7 @@
             </a>
         </header>
 
-        <div id="donate-money" class="is-collapsible {% if current_kind == 'money' %}is-active{%endif%}">
+        <div id="money-accordion" class="is-collapsible {% if current_kind == 'money' %}is-active{%endif%}">
             <div class="card-content donation-card">
                 <div class="container">
                     <div class="content">

--- a/ro_help/hub/templates/ngo/donate.html
+++ b/ro_help/hub/templates/ngo/donate.html
@@ -8,7 +8,7 @@
 {% block kind-kind-filters %}
 {% endblock%}
 
-<div class="container">
+<div id="donation-form" class="container">
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
 


### PR DESCRIPTION
### What does it fix?

Closes #252 

The current behaviour of the `detail.html` page already takes into consideration `kind=` url argument when loading the page and scrolls to either `Donate Resources` section or `Join as volunteer`.

There's a piece of JS doing this starting at line 293

For `kind=money` there were indeed some issues due to different ID naming for div elements holding the netopia form. That should be fixed in this PR.

`donate.html` also scrolls to form when users lands on that page from the ngo detail template.