### PR TITLE
added plain text version of the email.

### DIFF
--- a/ro_help/hub/templates/registration/password_reset_email.txt
+++ b/ro_help/hub/templates/registration/password_reset_email.txt
@@ -1,0 +1,11 @@
+Bună,
+
+Organizația ta a fost acceptată în platforma RoHelp. Te rugăm să intri in contul tau: {{ protocol}}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}, să adaugi detaliile necesare și să folosești platforma pentru a putea colecta donații sau sprijin, publicând nevoile identificate de organizație în secțiunea dedicată. În secțiunea de raportare vei putea să încarci raportul de utilizare al donațiilor. <br><br>
+
+Dacă întâmpini orice dificultate, te rugăm să ne trimiți un e-mail la contact@code4.ro . <br> <br>
+
+Seteaza parola initiala: "{{ protocol}}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %} <br><br>
+
+Mulțumim,<br>
+Echipa RoHelp
+


### PR DESCRIPTION
This PR adds a plain text version of the `password_reset_email` since django does it like this: https://docs.djangoproject.com/en/3.0/topics/email/#sending-alternative-content-types