### PR TITLE
Allow debug and sentry to be configured from env

### DIFF
--- a/ro_help/ro_help/settings/base.py
+++ b/ro_help/ro_help/settings/base.py
@@ -20,12 +20,13 @@ import environ
 root = environ.Path(__file__) - 3  # three folder back (/a/b/c/ - 3 = /)
 env = environ.Env(
     # set casting, default value
-    DEBUG=(bool, False),
+    DEBUG=(bool, True),
     ENABLE_DEBUG_TOOLBAR=(bool, False),
     USE_S3=(bool, False),
     ALLOWED_HOSTS=(list, []),
     RECAPTCHA_PUBLIC_KEY=(str, ""),
     RECAPTCHA_PRIVATE_KEY=(str, ""),
+    SENTRY_DSN=(str, ""),
 )
 environ.Env.read_env(f"{root}/.env")  # reading .env file
 
@@ -42,7 +43,7 @@ WEBROOT_DIR = env.str("WEBROOT_DIR", os.path.join(PROJECT_ROOT, "webroot/"))
 SECRET_KEY = "v*2$eed@gagp7f%kvb=zl%30c-(*gl9qppn0vv%sku#q7o&p64"
 
 # SECURITY WARNING: don"t run with debug turned on in production!
-DEBUG = True
+DEBUG = TEMPLATE_DEBUG = env.bool("DEBUG", True)
 
 ALLOWED_HOSTS = [".rohelp-102801068.eu-central-1.elb.amazonaws.com", "dev.rohelp.ro", "rohelp.ro", "prod.rohelp.ro"]
 
@@ -259,3 +260,15 @@ if env("RECAPTCHA_PUBLIC_KEY"):
     RECAPTCHA_PRIVATE_KEY = env("RECAPTCHA_PRIVATE_KEY")
 else:
     SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
+
+if env("SENTRY_DSN"):
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(
+        dsn=env("SENTRY_DSN"),
+        integrations=[DjangoIntegration()],
+        # If you wish to associate users to errors (assuming you are using
+        # django.contrib.auth) you may enable sending PII data.
+        send_default_pii=True,
+    )

--- a/ro_help/ro_help/settings/base.py
+++ b/ro_help/ro_help/settings/base.py
@@ -271,4 +271,5 @@ if env("SENTRY_DSN"):
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,
+        environment="staging" if DEBUG else "prod",
     )

--- a/ro_help/ro_help/settings/dev.py
+++ b/ro_help/ro_help/settings/dev.py
@@ -1,7 +1,5 @@
 from .base import *
 
-DEBUG = TEMPLATE_DEBUG = False
-
 INTERNAL_IPS = ["127.0.0.1", "localhost", "local.rohelp.ro", "192.168.99.100"]
 
 ALLOWED_HOSTS += ["localhost", "192.168.99.100", "local.rohelp.ro", "dev.rohelp.ro"]

--- a/ro_help/ro_help/settings/prod.py
+++ b/ro_help/ro_help/settings/prod.py
@@ -1,8 +1,6 @@
 from .base import *
 
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-
+# Fail-safe: make sure that we never run DEBUG in production
 DEBUG = TEMPLATE_DEBUG = False
 
 SECRET_KEY = env("SECRET_KEY")
@@ -13,11 +11,3 @@ MIDDLEWARE.append("whitenoise.middleware.WhiteNoiseMiddleware")
 
 STATIC_ROOT = os.path.join(BASE_DIR, "../", "static")
 STATICFILES_DIRS = []
-
-sentry_sdk.init(
-    dsn="https://fafd029cf71346c1b9c44397e6634b47@o375441.ingest.sentry.io/5194891",
-    integrations=[DjangoIntegration()],
-    # If you wish to associate users to errors (assuming you are using
-    # django.contrib.auth) you may enable sending PII data.
-    send_default_pii=True,
-)


### PR DESCRIPTION
Right now, we use the `dev.py` settings to run the staging environment and the local one.
In order to offer a little more flexibility, I moved the DEBUG and SENTRY_DSN configs to env and kept DEBUG, by default, on True (in order to maintain a seamless development experience).

We'll just need to add 2 env vars on our staging env:
  * `DEBUG` = `False`
  * `SENTRY_DSN` = ...
And one in our production environment:
  * `SENTRY_DSN` = ...